### PR TITLE
Implement ratelimit aborting

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -66,9 +66,9 @@ Format: Command separated list of **user id** and limit combo, separated by `:` 
 Example: `392827169497284619:100,227115752396685313:80`
 
 ##### RATELIMIT_ABORT_AFTER
-Amount of seconds a request should wait for ratelimits for aborting. `-1` means request will never abort, `0` means the request will abort in the event of any ratelimiting. The value may be larger than a single ratelimit window.
+Amount of seconds a request should wait for ratelimits befor aborting. `-1` means the request will never abort and `0` means the request will abort in the event of any form of ratelimiting. The value may be larger than a single ratelimit window.
 
-Default: -1
+Default: -1 (no aborting)
 
 ## Unstable env vars
 Collection of env vars that may be removed at any time, mainly used for Discord introducing new behaviour on their edge api versions

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -65,6 +65,11 @@ Allows you to define custom global request limits for one or multiple bots. The 
 Format: Command separated list of **user id** and limit combo, separated by `:` and with no spaces at all. Don't use application ids.
 Example: `392827169497284619:100,227115752396685313:80`
 
+##### RATELIMIT_ABORT_AFTER
+Amount of seconds a request should wait for ratelimits for aborting. `-1` means request will never abort, `0` means the request will abort in the event of any ratelimiting. The value may be larger than a single ratelimit window.
+
+Default: -1
+
 ## Unstable env vars
 Collection of env vars that may be removed at any time, mainly used for Discord introducing new behaviour on their edge api versions
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Configuration options are
 | MAX_BEARER_COUNT| number                                        | 1024                    |
 | DISABLE_HTTP_2  | bool                                          | true                    |
 | BOT_RATELIMIT_OVERRIDES | string list (comma separated)          | ""                      |
+| RATELIMIT_ABORT_AFTER | number                                  | -1                      |
 
 Information on each config var can be found [here](https://github.com/germanoeich/nirn-proxy/blob/main/CONFIG.md)
 
@@ -51,6 +52,16 @@ The proxy listens on all routes and relays them to Discord, while keeping track 
 When using the proxy, it is safe to remove the ratelimiting logic from clients and fire requests instantly, however, the proxy does not handle retries. If for some reason (i.e shared ratelimits, internal discord ratelimits, etc) the proxy encounters a 429, it will return that to the client. It is safe to immediately retry requests that return 429 or even setup retry logic elsewhere (like in a load balancer or service mesh).
 
 The proxy also guards against known scenarios that might cause a cloudflare ban, like too many webhook 404s or too many 401s.
+
+#### Ratelimit aborting
+
+The proxy allows requests to specify a `X-RateLimit-Abort-After` header (defaulted to the `RATELIMIT_ABORT_AFTER` variable). This sets the amount of seconds to wait in case of ratelimits before the proxy aborts the request and returns a 429 response.
+
+The point of ratelimit aborting is being able to send a request and set a maximum amount of time the request can be ratelimited. Certain enpoints have very high ratelimits and this configuration allow you to send the request and tell the proxy to abort it in case it needs to wait for the ratelimits. Compared to timeouts, this is a much more reliable approach in the event of instabilities of the API.
+
+The special (and default) value `-1` indicates a request which should not abort. Set the value to `0` to abort if any ratelimiting will be necessary. If the value is higher than the allowed window of the ratelimit - for example an abort time of `8` for a ratelimit of `5 / 5s` - the value will be subtracted each time the proxy waits for the ratelimit. The proxy does not pre-emptively calculate how long the request will need to wait for ratelimits, therefore the request will not immediately abort, so in the above example the request will abort after 5 seconds (`5s * 2` > `8`s) when the proxy waits for the second window.
+
+To use this effectively, you'll need to make changes to your library so that it does not attempt to retry a request sent with the header. In Python for example, this could be implemented as a context manager which catches an exception raised by the API methods.
 
 ### Proxy specific responses
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ The proxy also guards against known scenarios that might cause a cloudflare ban,
 
 #### Ratelimit aborting
 
-The proxy allows requests to specify a `X-RateLimit-Abort-After` header (defaulted to the `RATELIMIT_ABORT_AFTER` variable). This sets the amount of seconds to wait in case of ratelimits before the proxy aborts the request and returns a 429 response.
+The proxy allows requests to specify an `X-RateLimit-Abort-After` header (defaulted to the `RATELIMIT_ABORT_AFTER` variable). This sets the amount of seconds to wait in case of ratelimits before the proxy aborts the request and returns a 429 response.
 
-The point of ratelimit aborting is being able to send a request and set a maximum amount of time the request can be ratelimited. Certain enpoints have very high ratelimits and this configuration allow you to send the request and tell the proxy to abort it in case it needs to wait for the ratelimits. Compared to timeouts, this is a much more reliable approach in the event of instabilities of the API.
+The point of ratelimit aborting is being able to send a request and set a maximum amount of time the request can be ratelimited. Certain enpoints have very high ratelimits and this configuration allows you to send the request and tell the proxy to abort it in case it needs to wait for ratelimits. Compared to timeouts, this is a much more reliable approach in the event of instabilities of the API.
 
-The special (and default) value `-1` indicates a request which should not abort. Set the value to `0` to abort if any ratelimiting will be necessary. If the value is higher than the allowed window of the ratelimit - for example an abort time of `8` for a ratelimit of `5 / 5s` - the value will be subtracted each time the proxy waits for the ratelimit. The proxy does not pre-emptively calculate how long the request will need to wait for ratelimits, therefore the request will not immediately abort, so in the above example the request will abort after 5 seconds (`5s * 2` > `8`s) when the proxy waits for the second window.
+The special (and default) value `-1` indicates a request which should not abort. Set the value to `0` to abort if any ratelimiting will be necessary. If the value is higher than the allowed window of the ratelimit - for example an abort time of `8` for a ratelimit of `5 / 5s` - the value will be subtracted each time the proxy waits for the ratelimit.
+
+The proxy does not pre-emptively calculate how long a request will need to wait for ratelimits, therefore requests may not always immediately abort. In the above example with 8 seconds of abort time, the request will be aborted after roughly 5 seconds when the proxy fills the second window of the ratelimit and the request would have to wait for 10 seconds in total had it not been aborted.
 
 To use this effectively, you'll need to make changes to your library so that it does not attempt to retry a request sent with the header. In Python for example, this could be implemented as a context manager which catches an exception raised by the API methods.
 

--- a/lib/queue.go
+++ b/lib/queue.go
@@ -163,7 +163,7 @@ func safeSend(queue *QueueChannel, value *QueueItem) {
 	queue.ch <- value
 }
 
-func (q *RequestQueue) Queue(req *http.Request, res *http.ResponseWriter, path string, pathHash uint64) error {
+func (q *RequestQueue) Queue(req *http.Request, res *http.ResponseWriter, path string, pathHash uint64, defaultAbort int) error {
 	logger.WithFields(logrus.Fields{
 		"bucket": path,
 		"path": req.URL.Path,
@@ -180,7 +180,7 @@ func (q *RequestQueue) Queue(req *http.Request, res *http.ResponseWriter, path s
 
 		abort = int(valParsed)
 	} else {
-		abort = EnvGetInt("RATELIMIT_ABORT_AFTER", -1)
+		abort = defaultAbort
 	}
 
 	ch := q.getQueueChannel(path, pathHash)

--- a/lib/queue.go
+++ b/lib/queue.go
@@ -19,10 +19,14 @@ type QueueItem struct {
 	Res *http.ResponseWriter
 	doneChan chan *http.Response
 	errChan chan error
+	// -1 means no abort
+	abortTime int
 }
 
 type QueueChannel struct {
+	sync.Mutex
 	ch chan *QueueItem
+	waitingUntil time.Time
 	lastUsed time.Time
 }
 
@@ -145,7 +149,10 @@ func (q *RequestQueue) tickSweep() {
 	}
 }
 
-func safeSend(ch chan *QueueItem, value *QueueItem) {
+func safeSend(queue *QueueChannel, value *QueueItem) {
+	queue.Lock()
+	defer queue.Unlock() // Will be called after the deferred function below
+
 	defer func() {
 		if recover() != nil {
 			value.errChan <- errors.New("failed to send due to closed channel, sending 429 for client to retry")
@@ -153,7 +160,7 @@ func safeSend(ch chan *QueueItem, value *QueueItem) {
 		}
 	}()
 
-	ch <- value
+	queue.ch <- value
 }
 
 func (q *RequestQueue) Queue(req *http.Request, res *http.ResponseWriter, path string, pathHash uint64) error {
@@ -163,12 +170,31 @@ func (q *RequestQueue) Queue(req *http.Request, res *http.ResponseWriter, path s
 		"method": req.Method,
 	}).Trace("Inbound request")
 
+	var abort int
+	abortHeader := req.Header.Get("X-RateLimit-Abort-After")
+	if abortHeader != "" {
+		valParsed, err := strconv.ParseInt(abortHeader, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		abort = int(valParsed)
+	} else {
+		abort = EnvGetInt("RATELIMIT_ABORT_AFTER", -1)
+	}
+
 	ch := q.getQueueChannel(path, pathHash)
+	// waitingUntil may be a past time, making time.Until() negative. This is still handled like
+	// any time, assuming abort is positive.
+	if abort != -1 && abort < int(time.Until(ch.waitingUntil).Seconds()) {
+		Generate429(res)
+		return nil
+	}
 
 	doneChan := make(chan *http.Response)
 	errChan := make(chan error)
 
-	safeSend(ch.ch, &QueueItem{req, res, doneChan, errChan })
+	safeSend(ch, &QueueItem{ req, res, doneChan, errChan, abort })
 
 	select {
 	case <-doneChan:
@@ -184,7 +210,11 @@ func (q *RequestQueue) getQueueChannel(path string, pathHash uint64) *QueueChann
 	defer q.Unlock()
 	ch, ok := q.queues[pathHash]
 	if !ok {
-		ch = &QueueChannel{ make(chan *QueueItem, q.bufferSize), t }
+		ch = &QueueChannel{
+			ch: make(chan *QueueItem, q.bufferSize),
+			waitingUntil: t,
+			lastUsed: t,
+		}
 		q.queues[pathHash] = ch
 		// It's important that we only have 1 goroutine per channel
 		go q.subscribe(ch, path, pathHash)
@@ -264,6 +294,11 @@ func return401(item *QueueItem) {
 		item.errChan <- err
 		return
 	}
+	item.doneChan <- nil
+}
+
+func return429(item *QueueItem) {
+	Generate429(item.Res)
 	item.doneChan <- nil
 }
 
@@ -366,8 +401,33 @@ func (q *RequestQueue) subscribe(ch *QueueChannel, path string, pathHash uint64)
 				atomic.StoreInt64(q.isTokenInvalid, 999)
 			}
 		}
+
 		if remaining == 0 || resp.StatusCode == 429 {
-			time.Sleep(time.Until(time.Now().Add(resetAfter)))
+			// Before sleeping for the ratelimit, check if there are any requests that would like to be aborted
+			ch.Lock()
+			ch.waitingUntil = time.Now().Add(resetAfter)
+			duration := time.Until(ch.waitingUntil)
+			seconds := int(duration.Seconds())
+
+			length := len(ch.ch)
+			for i := 0; i < length; i++ {
+				abortItem := <-ch.ch
+
+				if abortItem.abortTime == -1 {
+					ch.ch <- abortItem
+					continue
+				}
+
+				abortItem.abortTime -= seconds
+				if abortItem.abortTime < 0 {
+					return429(abortItem)
+				} else {
+					ch.ch <- abortItem
+				}
+			}
+			ch.Unlock()
+
+			time.Sleep(duration)
 		}
 		prevRem, prevReset = remaining, resetAfter
 	}

--- a/main.go
+++ b/main.go
@@ -82,8 +82,9 @@ func main()  {
 
 	bufferSize = lib.EnvGetInt("BUFFER_SIZE", 50)
 	maxBearerLruSize := lib.EnvGetInt("MAX_BEARER_COUNT", 1024)
+	abort := lib.EnvGetInt("RATELIMIT_ABORT_AFTER", -1)
 
-	manager := lib.NewQueueManager(bufferSize, maxBearerLruSize)
+	manager := lib.NewQueueManager(bufferSize, maxBearerLruSize, abort)
 
 	mux := manager.CreateMux()
 


### PR DESCRIPTION
As discussed in our DMs, this PR implements ratelimit aborting -- allowing requests to be aborted if they will be ratelimited.

I have also updated the documentation in the README and config files.

Note that while documenting it, I realize that there's an issue with the 429 response sent when a request is aborted: there's no way to tell whether it is from the aborting made, or the request made which unexpectedly got ratelimited. This is fine for my use-case, as I'll always put the value to 0 but for any non-zero values this may be an important distinction to make. I'll leave this up to you on how to handle it.

Thank you for your help with this ❤️