### PR TITLE
Fix missed changes from switching status code of aborted requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The proxy also guards against known scenarios that might cause a cloudflare ban,
 
 #### Ratelimit aborting
 
-The proxy allows requests to specify an `X-RateLimit-Abort-After` header (defaulted to the `RATELIMIT_ABORT_AFTER` variable). This sets the amount of seconds to wait in case of ratelimits before the proxy aborts the request and returns a 429 response.
+The proxy allows requests to specify an `X-RateLimit-Abort-After` header (defaulted to the `RATELIMIT_ABORT_AFTER` variable). This sets the amount of seconds to wait in case of ratelimits before the proxy aborts the request and returns a 408 response.
 
 The point of ratelimit aborting is being able to send a request and set a maximum amount of time the request can be ratelimited. Certain enpoints have very high ratelimits and this configuration allows you to send the request and tell the proxy to abort it in case it needs to wait for ratelimits. Compared to timeouts, this is a much more reliable approach in the event of instabilities of the API.
 
@@ -63,11 +63,11 @@ The special (and default) value `-1` indicates a request which should not abort.
 
 The proxy does not pre-emptively calculate how long a request will need to wait for ratelimits, therefore requests may not always immediately abort. In the above example with 8 seconds of abort time, the request will be aborted after roughly 5 seconds when the proxy fills the second window of the ratelimit and the request would have to wait for 10 seconds in total had it not been aborted.
 
-To use this effectively, you'll need to make changes to your library so that it does not attempt to retry a request sent with the header. In Python for example, this could be implemented as a context manager which catches an exception raised by the API methods.
-
 ### Proxy specific responses
 
 The proxy may return a 408 Request Timeout if Discord takes more than $REQUEST_TIMEOUT milliseconds to respond. This allows you to identify and react to routes that have issues.
+
+Requests may also return a 408 status code in the event that they were aborted because of ratelimits, as documented above.
 
 ### Limitations
 


### PR DESCRIPTION
This PR fixes a few missed changes from #5 when the status code was changed from 429 to 408.